### PR TITLE
Check for existing handlers and filters

### DIFF
--- a/logger/logger.py
+++ b/logger/logger.py
@@ -37,7 +37,8 @@ def getLogger(svc_name='test', output='stdout', level=logging.INFO):
     logger.setLevel(level)
 
     f = ContextFilter(svc_name)
-    logger.addFilter(f)
+    if len(logger.filters) == 0:
+        logger.addFilter(f)
 
     if output == 'td-agent-forward':
         handler = fluent_handler.FluentHandler('application.logs', host='log-aggregator-service.default', port=24224)
@@ -47,7 +48,8 @@ def getLogger(svc_name='test', output='stdout', level=logging.INFO):
         formatter = logging.Formatter(json.dumps(log_custom_format), datefmt='%Y-%m-%dT%H:%M:%S')
 
     handler.setFormatter(formatter)
-    logger.addHandler(handler)
+    if not logger.hasHandlers():
+        logger.addHandler(handler)
 
     return logger
 
@@ -56,7 +58,8 @@ def getTracker(svc_name='test', output='stdout', level=logging.INFO):
     logger.setLevel(level)
 
     f = ContextFilter(svc_name)
-    logger.addFilter(f)
+    if len(logger.filters) == 0:
+        logger.addFilter(f)
 
     if output == 'td-agent-forward':
         handler = fluent_handler.FluentHandler('application.metrics', host='log-aggregator-service.default', port=24224)
@@ -66,6 +69,7 @@ def getTracker(svc_name='test', output='stdout', level=logging.INFO):
         formatter = logging.Formatter(json.dumps(metric_custom_format), datefmt='%Y-%m-%dT%H:%M:%S')
 
     handler.setFormatter(formatter)
-    logger.addHandler(handler)
+    if not logger.hasHandlers():
+        logger.addHandler(handler)
 
     return logger

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ requires = ["fluent-logger == 0.4.4"]
 
 setup(
     name='bufferapp-logger',
-    version='0.0.5',
+    version='0.0.6',
     url='https://github.com/bufferapp/python-logger',
     download_url='https://github.com/bufferapp/python-logger/archive/master.zip',
     author='Steven Cheng',


### PR DESCRIPTION
Since logging.getLogger returns an already existing logger instance
if the name is the same, multiple calls to `logger.getLogger` would
result in multiple handlers and filters being added. This would in
turn result in multiple log lines being printed, 1 for each handler.

This commit ensures that the logger instance returned only has 1
handler or filter attached. A better optimisation in the future
would be to exit out of the function immediately if the handler is
already set when the logger is returned.